### PR TITLE
Feat/delete deprecated timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "timezones.json",
+  "name": "@skycatch/timezones.json",
   "version": "1.5.2",
   "description": "Full list of UTC timezones",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/dmfilipenko/timezones.json.git"
+    "url": "git://github.com/skycatch/timezones.json.git"
   },
   "keywords": [
     "timezone",
@@ -16,7 +16,12 @@
   "author": "Dmitriy Filipenko",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dmfilipenko/timezones.json/issues"
+    "url": "https://github.com/skycatch/timezones.json/issues"
   },
-  "homepage": "https://github.com/dmfilipenko/timezones.json"
+  "homepage": "https://github.com/skycatch/timezones.json",
+  "contributors": [{
+    "name": "Sebatián Osorio",
+    "email": "sosorio@skycatch.com",
+    "url": "https://github.com/sirgalleto"
+  }]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skycatch/timezones.json",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Full list of UTC timezones",
   "main": "index.js",
   "repository": {

--- a/timezones.json
+++ b/timezones.json
@@ -85,8 +85,7 @@
       "America/Los_Angeles",
       "America/Tijuana",
       "America/Vancouver",
-      "America/Whitehorse",
-      "PST8PDT"
+      "America/Whitehorse"
     ]
   },
   {
@@ -127,8 +126,7 @@
       "America/Edmonton",
       "America/Inuvik",
       "America/Ojinaga",
-      "America/Yellowknife",
-      "MST7MDT"
+      "America/Yellowknife"
     ]
   },
   {
@@ -166,8 +164,7 @@
       "America/Rainy_River",
       "America/Rankin_Inlet",
       "America/Resolute",
-      "America/Winnipeg",
-      "CST6CDT"
+      "America/Winnipeg"
     ]
   },
   {
@@ -236,8 +233,7 @@
       "America/Pangnirtung",
       "America/Port-au-Prince",
       "America/Thunder_Bay",
-      "America/Toronto",
-      "EST5EDT"
+      "America/Toronto"
     ]
   },
   {
@@ -1332,7 +1328,6 @@
     "isdst": false,
     "text": "(UTC+12:00) Auckland, Wellington",
     "utc": [
-      "Antarctica/McMurdo",
       "Pacific/Auckland"
     ]
   },


### PR DESCRIPTION
I filtered the inmediatly non supported timezones by js running this script over the timezones list in datahub.

```
const timezones = [...]
const date = new Date()

timezones.forEach(({ value }) => {
  try{
    const newDate = new Date(
      date.toLocaleString('en-US', {
        timeZone: value
      })
    )
  } catch(e) {
    console.info(value)
  }
})
```

Result: 

```
PST8PDT
MST7MDT
CST6CDT
EST5EDT
Antarctica/McMurdo
```